### PR TITLE
[testing] fix unsafe uintptr usage to be GC-safe on go1.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
           - '1.20'
           - '1.21'
           - '1.22'
+          - '1.23'
+          - 'oldstable'
+          - 'stable'
     steps:
       -
         name: Checkout

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wincred
@@ -5,7 +6,6 @@ package wincred
 import (
 	"testing"
 	"time"
-	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -52,7 +52,7 @@ func BenchmarkUtf16ToByte(b *testing.B) {
 
 func TestGoBytes(t *testing.T) {
 	input := []byte{1, 2, 3, 4, 5}
-	output := goBytes(uintptr(unsafe.Pointer(&input[0])), uint32(len(input)))
+	output := goBytes(&input[0], uint32(len(input)))
 	assert.Equal(t, len(input), len(output))
 	assert.Equal(t, input[0], output[0])
 	assert.Equal(t, input[1], output[1])
@@ -65,7 +65,7 @@ func TestGoBytes(t *testing.T) {
 
 func TestGoBytes_Null(t *testing.T) {
 	assert.NotPanics(t, func() {
-		output := goBytes(0, 123)
+		output := goBytes(nil, 123)
 		assert.Equal(t, []byte{}, output)
 	})
 }
@@ -73,7 +73,7 @@ func TestGoBytes_Null(t *testing.T) {
 func BenchmarkGoBytes(b *testing.B) {
 	input := []byte{1, 2, 3, 4, 5}
 	for i := 0; i < b.N; i++ {
-		goBytes(uintptr(unsafe.Pointer(&input[0])), uint32(len(input)))
+		_ = goBytes(&input[0], uint32(len(input)))
 	}
 }
 
@@ -108,7 +108,7 @@ func TestConversion_CredentialBlob(t *testing.T) {
 	sys := sysFromCredential(cred)
 	res := sysToCredential(sys)
 	assert.Equal(t, uint32(3), sys.CredentialBlobSize)
-	assert.NotEqual(t, uintptr(0), sys.CredentialBlob)
+	assert.NotNil(t, res.CredentialBlob)
 	assert.Equal(t, cred.CredentialBlob, res.CredentialBlob)
 }
 
@@ -117,7 +117,7 @@ func TestConversion_CredentialBlob_Empty(t *testing.T) {
 	cred.CredentialBlob = []byte{} // empty blob
 	sys := sysFromCredential(cred)
 	res := sysToCredential(sys)
-	assert.Equal(t, uintptr(0), sys.CredentialBlob)
+	assert.Nil(t, sys.CredentialBlob)
 	assert.Equal(t, uint32(0), sys.CredentialBlobSize)
 	assert.Equal(t, []byte{}, res.CredentialBlob)
 }
@@ -127,7 +127,7 @@ func TestConversion_CredentialBlob_Nil(t *testing.T) {
 	cred.CredentialBlob = nil // nil blob
 	sys := sysFromCredential(cred)
 	res := sysToCredential(sys)
-	assert.Equal(t, uintptr(0), sys.CredentialBlob)
+	assert.Nil(t, sys.CredentialBlob)
 	assert.Equal(t, uint32(0), sys.CredentialBlobSize)
 	assert.Equal(t, []byte{}, res.CredentialBlob)
 }
@@ -140,7 +140,7 @@ func TestConversion_Attributes(t *testing.T) {
 	}
 	sys := sysFromCredential(cred)
 	res := sysToCredential(sys)
-	assert.NotEqual(t, uintptr(0), sys.Attributes)
+	assert.NotNil(t, sys.Attributes)
 	assert.Equal(t, uint32(2), sys.AttributeCount)
 	assert.Equal(t, cred.Attributes, res.Attributes)
 }
@@ -150,7 +150,7 @@ func TestConversion_Attributes_Empty(t *testing.T) {
 	cred.Attributes = []CredentialAttribute{}
 	sys := sysFromCredential(cred)
 	res := sysToCredential(sys)
-	assert.Equal(t, uintptr(0), sys.Attributes)
+	assert.Nil(t, sys.Attributes)
 	assert.Equal(t, uint32(0), sys.AttributeCount)
 	assert.Equal(t, []CredentialAttribute{}, res.Attributes)
 }
@@ -160,7 +160,7 @@ func TestConversion_Attributes_Nil(t *testing.T) {
 	cred.Attributes = nil
 	sys := sysFromCredential(cred)
 	res := sysToCredential(sys)
-	assert.Equal(t, uintptr(0), sys.Attributes)
+	assert.Nil(t, sys.Attributes)
 	assert.Equal(t, uint32(0), sys.AttributeCount)
 	assert.Equal(t, []CredentialAttribute{}, res.Attributes)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/danieljoos/wincred
 go 1.18
 
 require (
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.20.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/sys.go
+++ b/sys.go
@@ -5,6 +5,7 @@ package wincred
 
 import (
 	"reflect"
+	"runtime"
 	"syscall"
 	"unsafe"
 
@@ -33,10 +34,10 @@ type sysCREDENTIAL struct {
 	Comment            *uint16
 	LastWritten        windows.Filetime
 	CredentialBlobSize uint32
-	CredentialBlob     uintptr
+	CredentialBlob     *byte
 	Persist            uint32
 	AttributeCount     uint32
-	Attributes         uintptr
+	Attributes         *sysCREDENTIAL_ATTRIBUTE
 	TargetAlias        *uint16
 	UserName           *uint16
 }
@@ -46,7 +47,7 @@ type sysCREDENTIAL_ATTRIBUTE struct {
 	Keyword   *uint16
 	Flags     uint32
 	ValueSize uint32
-	Value     uintptr
+	Value     *byte
 }
 
 // https://docs.microsoft.com/en-us/windows/desktop/api/wincred/ns-wincred-_credentialw
@@ -93,6 +94,8 @@ func sysCredWrite(cred *Credential, typ sysCRED_TYPE) error {
 		uintptr(unsafe.Pointer(ncred)),
 		0,
 	)
+	// Make sure everything reachable from ncred stays alive through the call.
+	runtime.KeepAlive(ncred)
 	if ret == 0 {
 		return err
 	}


### PR DESCRIPTION
- testing https://github.com/danieljoos/wincred/pull/78

Replace uintptr fields with typed pointers so the GC considers them alive.

relates to changes in go1.25: https://go.dev/doc/go1.25#faster-slices

> Faster slices
>
> The compiler can now allocate the backing store for slices on the stack
> in more situations, which improves performance. This change has the potential
> to amplify the effects of incorrect `unsafe.Pointer` usage, see for example
> [issue 73199]. In order to track down these problems, the [bisect tool] can
> be used to find the allocation causing trouble using the `-compile=variablemake`
> flag. All such new stack allocations can also be turned off using
> `-gcflags=all=-d=variablemakehash=n`.

[issue 73199]: https://go.dev/issue/73199
[bisect tool]: https://pkg.go.dev/golang.org/x/tools/cmd/bisect

Assisted-by: OpenAI ChatGPT